### PR TITLE
Reorient the physical arena within the venue space

### DIFF
--- a/comp24/score-sheet-2024.svg
+++ b/comp24/score-sheet-2024.svg
@@ -8,7 +8,7 @@
    version="1.1"
    viewBox="0 0 744.09446 1052.3622"
    sodipodi:docname="score-sheet-2024.svg"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -26,17 +26,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1904"
-     inkscape:window-height="1020"
+     inkscape:window-width="1920"
+     inkscape:window-height="1104"
      id="namedview96"
      showgrid="false"
      inkscape:zoom="1.0033856"
-     inkscape:cx="367.75493"
-     inkscape:cy="522.23193"
-     inkscape:window-x="6"
-     inkscape:window-y="50"
+     inkscape:cx="457.45125"
+     inkscape:cy="561.59865"
+     inkscape:window-x="1920"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g11459"
+     inkscape:current-layer="g68"
      inkscape:pagecheckerboard="0"
      inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1"
@@ -219,7 +219,7 @@
      transform="translate(0,3.2302534e-5)">
     <g
        id="g3076"
-       transform="matrix(0.8074881,0,0,0.8074881,8.6964058,24.326113)">
+       transform="matrix(0.8074881,0,0,0.8074881,29.099238,14.951113)">
       <rect
          y="202.36946"
          x="50.007309"
@@ -246,11 +246,11 @@
            transform="translate(220.66737,52.212133)"><tspan
              x="226.19437"
              y="412.01242"
-             id="tspan25"><tspan
+             id="tspan6083"><tspan
                style="font-size:29.7793px;line-height:1.25"
-               id="tspan1">Planet 0 </tspan><tspan
+               id="tspan6079">Planet 0 </tspan><tspan
                style="font-size:22.0587px;line-height:1.25"
-               id="tspan3">(green)</tspan></tspan></text>
+               id="tspan6081">(green)</tspan></tspan></text>
         <text
            id="text11443"
            y="492.32669"
@@ -260,16 +260,16 @@
            transform="translate(502.47161,-117.21697)"><tspan
              x="249.17012"
              y="492.32669"
-             id="tspan27"><tspan
+             id="tspan6087"><tspan
    style="font-size:29.7793px"
-   id="tspan26">Planet 1</tspan><tspan
+   id="tspan6085">Planet 1</tspan><tspan
    y="492.32669"
-   id="tspan28"> </tspan></tspan><tspan
+   id="tspan6089"> </tspan></tspan><tspan
              x="249.17012"
-             y="519.90004"
-             id="tspan30"><tspan
+             y="519.90005"
+             id="tspan6093"><tspan
                style="font-size:22.0587px;line-height:1.25"
-               id="tspan29">(orange)</tspan></tspan></text>
+               id="tspan6091">(orange)</tspan></tspan></text>
         <text
            id="text11431"
            y="931.48834"
@@ -279,11 +279,11 @@
            transform="translate(-149.58458,-205.05422)"><tspan
              x="596.44635"
              y="931.48834"
-             id="tspan33"><tspan
+             id="tspan6099"><tspan
                style="font-size:29.7793px;line-height:1.25"
-               id="tspan31">Planet 2 </tspan><tspan
+               id="tspan6095">Planet 2 </tspan><tspan
                style="font-size:22.0587px;line-height:1.25"
-               id="tspan32">(purple)</tspan></tspan></text>
+               id="tspan6097">(purple)</tspan></tspan></text>
         <text
            xml:space="preserve"
            style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;white-space:pre;inline-size:165.286;display:inline;fill:#4d4d4d;fill-opacity:1;stroke:none"
@@ -293,16 +293,16 @@
            transform="translate(-305.22361,-339.12344)"><tspan
              x="448.96237"
              y="714.29242"
-             id="tspan35"><tspan
+             id="tspan6103"><tspan
    style="font-size:29.7793px"
-   id="tspan34">Planet 3</tspan><tspan
+   id="tspan6101">Planet 3</tspan><tspan
    y="714.29242"
-   id="tspan36"> </tspan></tspan><tspan
+   id="tspan6105"> </tspan></tspan><tspan
              x="448.96237"
-             y="741.86577"
-             id="tspan38"><tspan
+             y="741.86578"
+             id="tspan6109"><tspan
                style="font-size:22.0587px;line-height:1.25"
-               id="tspan37">(yellow)</tspan></tspan></text>
+               id="tspan6107">(yellow)</tspan></tspan></text>
       </g>
       <path
          style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2.32202;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -333,12 +333,12 @@
          style="font-size:28px;line-height:1.25">2024 Score Sheet</tspan></text>
     <text
        id="text3523"
-       y="387.55627"
-       x="138.6461"
+       y="378.18127"
+       x="159.04893"
        style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:11.5019px;line-height:0%;font-family:'Rockwell Extra Bold';-inkscape-font-specification:'Rockwell Extra Bold, Ultra-Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.958494"
        xml:space="preserve"><tspan
-         y="387.55627"
-         x="138.6461"
+         y="378.18127"
+         x="159.04893"
          id="tspan3525"
          style="font-size:26.8378px;line-height:1.25;stroke-width:0.958494"> </tspan></text>
     <use
@@ -356,20 +356,20 @@
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.37386px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.781155"
          x="161.94299"
-         y="133.73578"
+         y="152.48578"
          id="text3412-5-0"><tspan
            x="161.94299"
-           y="133.73578"
+           y="152.48578"
            id="tspan3497-4-0"
            style="font-size:21.8723px;line-height:1.25;stroke-width:0.781155">Match Number: _______</tspan></text>
       <text
          xml:space="preserve"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.37386px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.781155"
          x="304.0451"
-         y="133.34596"
+         y="152.09596"
          id="text3412-5-0-0-7"><tspan
            x="304.0451"
-           y="133.34596"
+           y="152.09596"
            id="tspan3497-4-0-6-3"
            style="font-size:21.8723px;line-height:1.25;stroke-width:0.781155">Scorer (print name): __________________</tspan></text>
     </g>
@@ -401,54 +401,55 @@
          y="866.88007"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.25px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;text-anchor:middle;stroke-width:0.958494"
          id="tspan3092">Robot Asteroids</tspan></text>
+    <text
+       id="text3412-3"
+       y="911.86707"
+       x="219.2915"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.5px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.958494"
+       xml:space="preserve"><tspan
+         id="tspan3497-6"
+         y="911.86707"
+         x="219.2915"
+         style="font-size:27.5px;line-height:1.25;stroke-width:0.958494">Robot 0: ____________</tspan></text>
+    <text
+       id="text3412-3-7"
+       y="911.86707"
+       x="522.33936"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.5px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.958494"
+       xml:space="preserve"><tspan
+         id="tspan3497-6-5"
+         y="911.86707"
+         x="522.33936"
+         style="font-size:27.5px;line-height:1.25;stroke-width:0.958494">Robot 1: ____________</tspan></text>
+    <text
+       id="text3412-3-7-3"
+       y="956.27832"
+       x="219.2915"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.5px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.958494"
+       xml:space="preserve"><tspan
+         id="tspan3497-6-5-5"
+         y="956.27832"
+         x="219.2915"
+         style="font-size:27.5px;line-height:1.25;stroke-width:0.958494">Robot 3: ____________</tspan></text>
+    <text
+       id="text3412-3-7-6"
+       y="956.27832"
+       x="522.33936"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.5px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.958494"
+       xml:space="preserve"><tspan
+         id="tspan3497-6-5-2"
+         y="956.27832"
+         x="522.33936"
+         style="font-size:27.5px;line-height:1.25;stroke-width:0.958494">Robot 2: ____________</tspan></text>
     <g
-       id="g4077"
-       transform="matrix(0.95849432,0,0,0.95849432,15.460922,-86.287037)">
-      <text
-         id="text3412-3"
-         y="1041.3772"
-         x="212.65706"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.6908px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none"
-         xml:space="preserve"><tspan
-           id="tspan3497-6"
-           y="1041.3772"
-           x="212.65706"
-           style="font-size:28.6908px;line-height:1.25">Robot 0: ____________</tspan></text>
-      <text
-         id="text3412-3-7"
-         y="1041.3772"
-         x="528.82782"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.6908px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none"
-         xml:space="preserve"><tspan
-           id="tspan3497-6-5"
-           y="1041.3772"
-           x="528.82782"
-           style="font-size:28.6908px;line-height:1.25">Robot 1: ____________</tspan></text>
-      <text
-         id="text3412-3-7-3"
-         y="1087.7115"
-         x="212.65706"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.6908px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none"
-         xml:space="preserve"><tspan
-           id="tspan3497-6-5-5"
-           y="1087.7115"
-           x="212.65706"
-           style="font-size:28.6908px;line-height:1.25">Robot 3: ____________</tspan></text>
-      <text
-         id="text3412-3-7-6"
-         y="1087.7115"
-         x="528.82782"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:28.6908px;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none"
-         xml:space="preserve"><tspan
-           id="tspan3497-6-5-2"
-           y="1087.7115"
-           x="528.82782"
-           style="font-size:28.6908px;line-height:1.25">Robot 2: ____________</tspan></text>
+       id="g1140"
+       transform="translate(20.402838,-9.375)">
       <g
          id="g39-7"
-         transform="translate(-366.70517,210.55779)" />
+         transform="matrix(0.95849432,0,0,0.95849432,-336.0239,115.53141)" />
       <g
-         id="g1">
+         id="g1"
+         transform="matrix(0.95849432,0,0,0.95849432,15.460922,-86.287037)">
         <text
            id="use3570-5"
            y="447.51447"
@@ -470,7 +471,7 @@
       </g>
       <g
          id="g57"
-         transform="translate(11.932481,-546.64505)">
+         transform="matrix(0.95849432,0,0,0.95849432,26.898137,-610.24321)">
         <g
            id="g73"
            transform="translate(0,0.26653331)">
@@ -536,22 +537,28 @@
          y="0"
          xlink:href="#g57"
          id="use60"
-         transform="translate(132.25055,265.09109)" />
+         transform="translate(126.7614,254.0883)"
+         width="100%"
+         height="100%" />
       <use
          x="0"
          y="0"
          xlink:href="#use60"
          id="use61"
-         transform="translate(-132.25055,273.49684)" />
+         transform="translate(-126.7614,262.14516)"
+         width="100%"
+         height="100%" />
       <use
          x="0"
          y="0"
          xlink:href="#use61"
          id="use62"
-         transform="translate(-344.28084,-273.49684)" />
+         transform="translate(-329.99123,-262.14517)"
+         width="100%"
+         height="100%" />
       <g
          id="g10"
-         transform="translate(265.58625,53.861553)">
+         transform="matrix(0.95849432,0,0,0.95849432,270.02383,-34.661044)">
         <text
            id="text10"
            y="447.51447"
@@ -573,7 +580,7 @@
       </g>
       <g
          id="g12"
-         transform="translate(-270.298,53.861553)">
+         transform="matrix(0.95849432,0,0,0.95849432,-243.61818,-34.661044)">
         <text
            id="text12"
            y="447.51447"
@@ -595,7 +602,7 @@
       </g>
       <g
          id="g14"
-         transform="translate(0.30763238,341.71139)">
+         transform="matrix(0.95849432,0,0,0.95849432,15.755786,241.24139)">
         <text
            id="text14"
            y="447.51447"
@@ -617,7 +624,7 @@
       </g>
       <g
          id="g2"
-         transform="translate(0.30763238,186.8946)">
+         transform="matrix(0.95849432,0,0,0.95849432,15.755786,92.850376)">
         <g
            id="g3"
            transform="translate(0,-16.123896)">
@@ -643,7 +650,7 @@
       </g>
       <g
          id="g69"
-         transform="translate(15.649545,1.4120965)">
+         transform="matrix(0.95849432,0,0,0.95849432,30.460922,-84.933551)">
         <g
            id="g71">
           <text
@@ -660,12 +667,12 @@
                sodipodi:role="line"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9537px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:end;text-anchor:end;stroke-width:2.21805"
                x="296.25101"
-               y="329.89398"
+               y="329.77988"
                id="tspan55">Fully left Planet ▢</tspan><tspan
                sodipodi:role="line"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9537px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:end;text-anchor:end;stroke-width:2.21805"
                x="296.25101"
-               y="352.06964"
+               y="351.84146"
                id="tspan58">Disqualified ▢</tspan></text>
           <text
              xml:space="preserve"
@@ -681,7 +688,7 @@
                sodipodi:role="line"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9537px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:end;text-anchor:end;stroke-width:2.21805"
                x="296.25101"
-               y="403.36658"
+               y="403.25247"
                id="tspan58-7">Egg in 'Ship ▢</tspan></text>
           <text
              xml:space="preserve"
@@ -692,7 +699,7 @@
       </g>
       <g
          id="g70"
-         transform="translate(0,28.092701)">
+         transform="matrix(0.95849432,0,0,0.95849432,15.460922,-59.360343)">
         <text
            xml:space="preserve"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16.9537px;line-height:1.3;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:2.21805;stroke-dasharray:2.21805, 2.21805"
@@ -707,12 +714,12 @@
              sodipodi:role="line"
              style="font-size:16.9537px;stroke-width:2.21805"
              x="45.052444"
-             y="707.40869"
+             y="707.29462"
              id="tspan65">▢ Fully left Planet</tspan><tspan
              sodipodi:role="line"
              style="font-size:16.9537px;stroke-width:2.21805"
              x="45.052444"
-             y="729.58435"
+             y="729.35614"
              id="tspan68">▢ Disqualified</tspan></text>
         <text
            xml:space="preserve"
@@ -728,32 +735,36 @@
              sodipodi:role="line"
              style="font-size:16.9537px;stroke-width:2.21805"
              x="45.052444"
-             y="780.81293"
+             y="780.69885"
              id="tspan68-0">▢ Egg in 'Ship</tspan></text>
       </g>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.6495px;line-height:1.3;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:2.21805;stroke-dasharray:2.21805, 2.21805"
-         x="79.103096"
-         y="694.26373"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;line-height:1.3;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:2.12599;stroke-dasharray:2.12599, 2.12599"
+         x="91.280792"
+         y="579.16083"
          id="text63"><tspan
            sodipodi:role="line"
            id="tspan63"
-           style="stroke-width:2.21805"
-           x="79.103096"
-           y="694.26373" /></text>
+           style="stroke-width:2.12599"
+           x="91.280792"
+           y="579.16083" /></text>
       <use
          x="0"
          y="0"
          xlink:href="#g69"
          id="use71"
-         transform="translate(381.77513,404.12695)" />
+         transform="translate(365.92929,387.35338)"
+         width="100%"
+         height="100%" />
       <use
          x="0"
          y="0"
          xlink:href="#use71"
          id="use72"
-         transform="translate(-381.77513,134.46098)" />
+         transform="translate(-365.9293,128.88008)"
+         width="100%"
+         height="100%" />
     </g>
     <g
        id="Symbol-and-Text"
@@ -770,20 +781,21 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:19.1699px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.898588"
-       x="337.15799"
-       y="169.99036"
+       style="font-style:normal;font-weight:normal;font-size:19.1699px;line-height:1.25;font-family:sans-serif;writing-mode:tb-rl;text-orientation:upright;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.898588"
+       x="43.018375"
+       y="470.53677"
        id="text4257"><tspan
          id="tspan4255"
-         style="font-size:19.1699px;stroke-width:0.898588"
-         x="337.15799"
-         y="169.99036">Stage</tspan></text>
+         style="font-size:19.1699px;writing-mode:tb-rl;text-orientation:upright;stroke-width:0.898588"
+         x="43.018375"
+         y="470.53677">Stage</tspan></text>
     <rect
        style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.91669;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.87451"
        id="rect7277"
-       width="646.98364"
+       width="646.98303"
        height="28.754829"
-       x="49.008163"
-       y="147.82518" />
+       x="-824.8432"
+       y="28.63628"
+       transform="rotate(-90)" />
   </g>
 </svg>


### PR DESCRIPTION
We're rotating the layout of the physical arena to better match the default perspective of the match operations staff, who spend much of their time in staging, which is adjacent to the stage rather than opposite it.

This implements the change described in https://github.com/srobo/arena/pull/5#issuecomment-1996042968.